### PR TITLE
Production-readiness: prior work, CHANGELOG backfill, dashboard KPI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  checks:
+    name: ruff + mypy + pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install the package with dev extras
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Ruff format check + lint, mypy, pytest
+        run: make all-checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,100 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-06-04
+
+Robustness and quality hardening. Both public surfaces
+(`create_report`, `ReportGenerator`) are preserved and the default
+report output is unchanged.
+
+### Added
+- Shared input validation (`core/validation.py`) reused by both
+  `create_report()` and the CLI, including fastp JSON structure
+  checks.
+
+### Changed
+- Empty or malformed Kaiju / Kraken / flagstat inputs now raise a
+  clear `DataProcessingError` instead of an `IndexError`.
+- Broad `except Exception` sites replaced with specific exception
+  types.
+- Magic numbers (bar step height, the sub-1 % dashboard filter)
+  moved into the configuration; the four `_apply_styling` overrides
+  collapsed onto a single `PRESERVE_CHART_HEIGHT` base-class flag.
+- `mypy` is now enforced as part of `make all-checks` (0 errors,
+  previously 53); critical-path test coverage raised to 77 % (from
+  45 %). Pre-commit configuration refreshed to ruff + mypy. Empty-file
+  and threshold-precedence contracts documented.
+
+## [0.8.11] - 2026-05-26
+
+### Added
+- `create_report()` gains a `primary_host` parameter.
+
+### Changed
+- `__version__` is read dynamically from the installed-package
+  metadata so it tracks `pyproject.toml`. Test-suite tidy.
+
+## [0.8.10] - 2026-05-26
+
+### Changed
+- Standardised the narrow bar styling across the Kraken, Kaiju,
+  BLAST and Host alignment charts.
+
+## [0.8.9] - 2026-05-25
+
+### Changed
+- Dashboard landing cards drop rows below 1 % of reads to reduce
+  noise.
+
+## [0.8.8] - 2026-05-25
+
+### Changed
+- Assembly classification layout polish.
+
+## [0.8.7] - 2026-05-25
+
+### Changed
+- Surface the ICTV-canonical species names in the Dashboard and the
+  contig table.
+
+## [0.8.6] - 2026-05-25
+
+### Fixed
+- Host alignment: corrected bar height, surfaced the host name, and
+  made the primary and secondary panels symmetric.
+
+## [0.8.5] - 2026-05-25
+
+### Changed
+- Tab and banner alignment; dead-code purge; raw column-name
+  handling.
+
+## [0.8.4] - 2026-05-25
+
+### Removed
+- The broken "Download contig table as CSV" button.
+
+## [0.8.3] - 2026-05-25
+
+### Changed
+- Dropped the header filters from the Dashboard tables.
+
+## [0.8.2] - 2026-05-25
+
+### Added
+- Per-column header filters on the Coverage and Dashboard tables.
+
+## [0.8.1] - 2026-05-25
+
+### Added
+- Per-column header filters on the BLAST contig table.
+
+## [0.8.0] - 2026-05-25
+
+### Added
+- Light, brand-aligned report header with the embedded reportHanter
+  wordmark.
+
 ## [0.7.0] - 2026-05-24
 
 ### Added
@@ -79,6 +173,87 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Host alignment, Classification of reads, Assembly statistics,
   Assembly classification, Alignment coverage) keep their layout
   and order.
+
+## [0.5.11] - 2026-05-23
+
+### Changed
+- Compact host-alignment bar.
+
+## [0.5.10] - 2026-05-23
+
+### Added
+- NCBI Nucleotide link formatter for the `accession` and `chrom`
+  columns.
+
+## [0.5.9] - 2026-05-23
+
+### Changed
+- Assembly classification split into two charts: contig count and
+  cumulative bp shown separately.
+
+## [0.5.8] - 2026-05-22
+
+### Changed
+- Coverage references use a matched ordering between the summary
+  table and the per-reference tabs (row-click drill-in removed; the
+  table row order pins the tab order).
+
+## [0.5.7] - 2026-05-22
+
+### Changed
+- Coverage ordering plus row-click drill-in; Host header
+  de-duplication; wider Assembly chart.
+
+## [0.5.6] - 2026-05-22
+
+### Changed
+- UX polish: chart consolidation, a Coverage summary table, an
+  Assembly comparison view and the Host KPI strip.
+
+## [0.5.5] - 2026-05-22
+
+### Added
+- Cumulative-bp chart, a per-reference coverage statistics table and
+  per-assembler QUAST labels.
+
+## [0.5.4] - 2026-05-22
+
+### Changed
+- Six-tab data-flow layout.
+
+## [0.5.3] - 2026-05-22
+
+### Changed
+- Dedicated Assembly section for QUAST, separate from Classification
+  of Contigs.
+
+## [0.5.2] - 2026-05-22
+
+### Changed
+- QUAST sub-tab relocated to Classification of Contigs.
+
+## [0.5.1] - 2026-05-21
+
+### Added
+- `sources` column on the coverage labels; per-assembler sub-tab
+  layout.
+
+## [0.5.0] - 2026-05-21
+
+### Added
+- Multi-assembler contig table: BLAST CSVs are accepted as a list
+  (one per assembler) and the contig table carries an `assembler`
+  column.
+
+## [0.4.2] - 2026-05-21
+
+### Fixed
+- Dropped `interactive()` on the nominal-axis bar charts.
+
+## [0.4.1] - 2026-05-21
+
+### Fixed
+- Bars-only charts, fixing blank Kraken / Kaiju / BLAST panels.
 
 ## [0.4.0] - 2026-05-21
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,21 +11,6 @@ examples/
   configurations/
     README.md
     config_example.json        Default-generator configuration
-  demos/
-    enhanced_visualization_demo.py
-                               Walkthrough of the enhanced
-                               visualisation layer
-```
-
-Visualisation preset files (`visualization_scientific.json`,
-`visualization_executive.json`, `visualization_minimal.json`,
-`visualization_publication.json`,
-`visualization_comprehensive.json`) are not committed; generate them
-on demand:
-
-```python
-from reporthanter.visualization import create_visualization_examples
-create_visualization_examples()
 ```
 
 ## Running the default report from the command line
@@ -37,7 +22,7 @@ reporthanter \
     --kaiju_table    your_kaiju.tsv \
     --fastp_json     your_fastp.json \
     --flagstat_file  your_flagstat.txt \
-    --coverage_folder your_plots/ \
+    --mosdepth_regions your_regions.bed.gz \
     --output         report.html \
     --sample_name    "Example_Sample"
 ```
@@ -63,7 +48,7 @@ report = create_report(
     kaiju_table="your_kaiju.tsv",
     fastp_json="your_fastp.json",
     flagstat_file="your_flagstat.txt",
-    coverage_folder="your_plots/",
+    mosdepth_regions="your_regions.bed.gz",
     sample_name="Example_Sample",
 )
 report.save("python_report.html")
@@ -82,69 +67,32 @@ report = generator.generate_report(
     kaiju_table="your_kaiju.tsv",
     fastp_json="your_fastp.json",
     flagstat_file="your_flagstat.txt",
-    coverage_folder="your_plots/",
+    mosdepth_regions="your_regions.bed.gz",
     sample_name="Example_Sample",
 )
 generator.save_report(report, "python_report.html")
 ```
 
-## Enhanced visualisation layer
+## Multi-assembler input
 
-Note the keyword difference: the enhanced generator takes
-`blast_file`, the default generator takes `blastn_file`.
-
-```python
-from reporthanter.visualization import EnhancedReportGenerator
-
-generator = EnhancedReportGenerator(viz_config="scientific")
-report = generator.generate_enhanced_report(
-    kraken_file="your_kraken.tsv",
-    kaiju_table="your_kaiju.tsv",
-    blast_file="your_blast.csv",
-    fastp_json="your_fastp.json",
-    flagstat_file="your_flagstat.txt",
-    coverage_folder="your_plots/",
-)
-```
-
-Available presets: `scientific`, `executive`, `minimal`,
-`publication`.
-
-To use a JSON configuration file, load it through
-`VisualizationConfigManager` and pass the resulting
-`VisualizationConfig`:
-
-```python
-from pathlib import Path
-from reporthanter.visualization import (
-    EnhancedReportGenerator, VisualizationConfigManager,
-)
-
-viz_manager = VisualizationConfigManager(Path("my_viz_config.json"))
-generator = EnhancedReportGenerator(viz_config=viz_manager.config)
-```
-
-## Demo script
+`--blastn_file`, `--quast_report` and `--genomad_summary` accept
+repeated values, one per assembler, so a virusHanter2 run with
+several assemblers can pass each path in turn:
 
 ```bash
-python examples/demos/enhanced_visualization_demo.py
+reporthanter \
+    --blastn_file MEGAHIT/blast.csv \
+    --blastn_file metaSPAdes/blast.csv \
+    --kraken_file your_kraken.tsv \
+    --kaiju_table your_kaiju.tsv \
+    --fastp_json  your_fastp.json \
+    --flagstat_file your_flagstat.txt \
+    --mosdepth_regions your_regions.bed.gz \
+    --output report.html
 ```
 
-The script walks through the available chart types, colour
-schemes, layout templates and the configuration system, and prints
-their effect on small synthetic data.
-
-## Validating a configuration
-
-```python
-from reporthanter.visualization import VisualizationConfigManager
-
-manager = VisualizationConfigManager()
-issues = manager.validate_config(manager.get_preset("scientific"))
-if issues:
-    for issue in issues:
-        print(issue)
-```
+The singular form (one `--blastn_file`) still works for a
+single-assembler run.
 
 ## See also
 

--- a/reporthanter/core/config.py
+++ b/reporthanter/core/config.py
@@ -80,11 +80,13 @@ class DefaultConfig(ConfigProvider):
         "logging": {"level": "INFO", "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s"},
     }
 
-    def __init__(self, config_file: Path | None = None):
+    def __init__(self, config_file: str | Path | None = None):
         # deepcopy so per-instance mutations don't leak into DEFAULT_CONFIG
         self.config = copy.deepcopy(self.DEFAULT_CONFIG)
-        if config_file and config_file.exists():
-            self._load_config_file(config_file)
+        if config_file is not None:
+            config_file = Path(config_file)
+            if config_file.exists():
+                self._load_config_file(config_file)
 
     def _load_config_file(self, config_file: Path) -> None:
         """Load configuration from JSON file."""
@@ -129,10 +131,18 @@ class DefaultConfig(ConfigProvider):
                 base[key] = value
 
     def get_config(self, section: str | None = None) -> dict[str, Any]:
-        """Get configuration dictionary."""
-        if section:
-            return self.config.get(section, {})  # type: ignore[return-value]
-        return self.config
+        """Get a configuration sub-section.
+
+        ``section`` may be a top-level key (``"plotting"``) or a
+        dotted path into nested dictionaries (``"filtering.kraken"``).
+        Returns an empty dict when the section is absent or does not
+        resolve to a dict, so callers can safely splat the result as
+        keyword arguments.
+        """
+        if section is None:
+            return self.config
+        value = self.get(section)
+        return value if isinstance(value, dict) else {}
 
     def get(self, key: str, default: Any = None) -> Any:
         """Get a specific configuration value using dot notation."""

--- a/reporthanter/panel_report_cli.py
+++ b/reporthanter/panel_report_cli.py
@@ -14,6 +14,11 @@ from pathlib import Path
 from reporthanter.core.config import DefaultConfig
 from reporthanter.core.exceptions import ConfigurationError, ReportHanterError
 from reporthanter.core.validation import validate_report_inputs
+from reporthanter.processors.coverage_processor import CoverageProcessor
+from reporthanter.processors.fastp_processor import FastpProcessor
+from reporthanter.processors.flagstat_processor import FlagstatProcessor
+from reporthanter.processors.kaiju_processor import KaijuProcessor
+from reporthanter.processors.kraken_processor import KrakenProcessor
 from reporthanter.report.generator import ReportGenerator
 
 
@@ -139,6 +144,13 @@ def main() -> None:
         logger.info("Input validation passed")
 
         if args.validate_only:
+            # Existence/size checks above do not parse the files, so a
+            # structurally broken but present input would pass and only
+            # fail later during real generation. Parse the required
+            # structural inputs through their processors so --validate_only
+            # actually catches malformed content.
+            logger.info("Validating input contents...")
+            validate_input_contents(args, config)
             logger.info("Validation complete. Exiting.")
             return
 
@@ -206,6 +218,48 @@ def validate_inputs(args: argparse.Namespace) -> None:
         for error in errors:
             logging.error(error)
         raise ConfigurationError(f"Output path validation failed with {len(errors)} error(s)")
+
+
+def validate_input_contents(args: argparse.Namespace, config: DefaultConfig) -> None:
+    """Parse the required structural inputs to catch malformed content.
+
+    Existence/size checks in :func:`validate_inputs` do not open the
+    files. This parses each required structural input through its
+    processor (the same processors and config sections the report uses),
+    so ``--validate_only`` surfaces a corrupt Kraken/Kaiju TSV, a
+    non-JSON fastp file, a malformed flagstat, or an unreadable mosdepth
+    BED before a real run is attempted. Optional and empty-tolerated
+    inputs (BLAST, QUAST, geNomad) are left to generation, where their
+    sections already degrade gracefully.
+
+    Raises :exc:`ConfigurationError` listing every input that failed to
+    parse.
+    """
+    checks = (
+        ("Kraken file", KrakenProcessor(config.get_config("kraken")), args.kraken_file),
+        ("Kaiju table", KaijuProcessor(config.get_config("kaiju")), args.kaiju_table),
+        ("FastP JSON", FastpProcessor(config.get_config("fastp")), args.fastp_json),
+        ("Flagstat file", FlagstatProcessor(config.get_config("flagstat")), args.flagstat_file),
+        (
+            "Mosdepth regions file",
+            CoverageProcessor(config.get_config("coverage")),
+            args.mosdepth_regions,
+        ),
+    )
+    errors: list[str] = []
+    for name, processor, path in checks:
+        try:
+            processor.process(path)
+        except ReportHanterError as exc:
+            errors.append(f"{name} could not be parsed: {exc}")
+
+    if errors:
+        for error in errors:
+            logging.error(error)
+        raise ConfigurationError(
+            f"Input content validation failed with {len(errors)} error(s); "
+            "see the log output above for details."
+        )
 
 
 def setup_logging(log_level: str, config: DefaultConfig | None = None) -> None:

--- a/reporthanter/processors/flagstat_processor.py
+++ b/reporthanter/processors/flagstat_processor.py
@@ -86,6 +86,11 @@ class FlagstatProcessor(BaseDataProcessor):
             ) from e
 
         percent_mapped = 0.0 if total_reads == 0 else total_mapped / total_reads * 100
+        # Clamp to [0, 100]: some samtools outputs count supplementary /
+        # secondary alignments so "with itself and mate mapped" exceeds
+        # "paired in sequencing", which would otherwise yield a >100%
+        # mapped tile and a negative "unaligned" segment in the chart.
+        percent_mapped = max(0.0, min(100.0, percent_mapped))
 
         return total_reads, percent_mapped
 

--- a/reporthanter/processors/kaiju_processor.py
+++ b/reporthanter/processors/kaiju_processor.py
@@ -76,12 +76,16 @@ class KaijuProcessor(BaseDataProcessor):
         unclassified_rows = data.loc[data.taxon_name == "unclassified"]
         unclassified_pct = unclassified_rows.percent.iloc[0] if len(unclassified_rows) > 0 else 0.0
 
-        # Filter out unclassified entries and apply cutoff
+        # Filter out unclassified entries and apply cutoff. Both masks
+        # use callables so they evaluate against the chained (dropped /
+        # sorted) frame rather than the original `data`; a boolean Series
+        # indexed over `data` only aligns today because the index is
+        # preserved and unique through the prior steps.
         filtered_df = (
             data.drop(columns=["file"], errors="ignore")
             .sort_values("percent", ascending=False)
-            .loc[data.taxon_name != "unclassified"]
-            .loc[data.percent > cutoff]
+            .loc[lambda d: d.taxon_name != "unclassified"]
+            .loc[lambda d: d.percent > cutoff]
             .head(max_entries)
         )
 

--- a/reporthanter/processors/kraken_processor.py
+++ b/reporthanter/processors/kraken_processor.py
@@ -114,10 +114,14 @@ class KrakenProcessor(BaseDataProcessor):
         unclassified_rows = data.loc[data.domain == "unclassified"]
         unclassified_pct = unclassified_rows.percent.iloc[0] if len(unclassified_rows) > 0 else 0.0
 
-        # Filter by taxonomy level and cutoff
+        # Filter by taxonomy level and cutoff. The cutoff mask uses a
+        # callable so it is evaluated against the already level-filtered
+        # frame rather than the original `data` (a boolean Series indexed
+        # over `data` only happens to align today because the index is
+        # preserved and unique).
         filtered_df = (
             data.loc[data.tax_lvl == self.TAXONOMY_LEVELS[level]]
-            .loc[data.percent > cutoff]
+            .loc[lambda d: d.percent > cutoff]
             .sort_values("percent", ascending=False)
         )
 

--- a/reporthanter/report/dashboard.py
+++ b/reporthanter/report/dashboard.py
@@ -69,6 +69,28 @@ def _compact_table(
     )
 
 
+def _kraken_viral_percent(kdata: pd.DataFrame) -> float:
+    """Percent of reads Kraken assigned to the Viruses domain (0-100).
+
+    Reads the Viruses superkingdom row -- ``tax_lvl == "D"`` in the
+    standard pluspf database, ``"R1"`` in the smaller viral-only
+    ``k2_viral_*`` databases -- from the processed Kraken frame, whose
+    ``percent`` column is already a fraction (``KrakenProcessor.process``
+    divides by 100). This mirrors the canonical ``kraken_virus_percent``
+    in ``aggregate_run_information`` so the Dashboard KPI agrees with the
+    run-information CSV and the Classification-of-reads tab rather than
+    reporting the total-classified fraction. Returns 0.0 when no Viruses
+    row is present.
+    """
+    if "name" not in kdata.columns or "tax_lvl" not in kdata.columns:
+        return 0.0
+    rows = kdata.loc[
+        (kdata["tax_lvl"].isin(["D", "R1"])) & (kdata["name"] == "Viruses"),
+        "percent",
+    ]
+    return float(rows.iloc[0]) * 100 if not rows.empty else 0.0
+
+
 class DashboardSection(ReportSection):
     """First-tab landing summary."""
 
@@ -222,11 +244,12 @@ class DashboardSection(ReportSection):
             try:
                 kp = KrakenProcessor(self.config.get_config("kraken"))
                 kdata = kp.process(kraken_file)
-                # virus_only is structural for this card and overrides
-                # whatever the user config sets.
-                kraken_cfg = {**self.config.get_config("filtering.kraken"), "virus_only": True}
-                _filt, unclassified = kp.filter_data(kdata, **kraken_cfg)
-                kraken_pct = f"{(1.0 - float(unclassified)) * 100:.1f}%"
+                # The tile is labelled "Reads classified (Kraken viral)", so it
+                # must report the Viruses-domain fraction, not the fraction
+                # classified to any taxon. The previous (1 - unclassified)
+                # computation ignored the virus filter entirely and overstated
+                # the viral signal on host/bacteria-heavy samples.
+                kraken_pct = f"{_kraken_viral_percent(kdata):.1f}%"
             except (
                 OSError,
                 json.JSONDecodeError,

--- a/reporthanter/report/dashboard.py
+++ b/reporthanter/report/dashboard.py
@@ -222,11 +222,10 @@ class DashboardSection(ReportSection):
             try:
                 kp = KrakenProcessor(self.config.get_config("kraken"))
                 kdata = kp.process(kraken_file)
-                _filt, unclassified = kp.filter_data(
-                    kdata,
-                    **self.config.get_config("filtering.kraken"),
-                    virus_only=True,
-                )
+                # virus_only is structural for this card and overrides
+                # whatever the user config sets.
+                kraken_cfg = {**self.config.get_config("filtering.kraken"), "virus_only": True}
+                _filt, unclassified = kp.filter_data(kdata, **kraken_cfg)
                 kraken_pct = f"{(1.0 - float(unclassified)) * 100:.1f}%"
             except (
                 OSError,
@@ -299,7 +298,8 @@ class DashboardSection(ReportSection):
             kdata = kp.process(kraken_file)
             config = dict(self.config.get_config("filtering.kraken"))
             config["max_entries"] = 5
-            filt, _ = kp.filter_data(kdata, virus_only=True, **config)
+            config["virus_only"] = True
+            filt, _ = kp.filter_data(kdata, **config)
             cols = ["name", "percent", "count_clades"]
             if "aliases" in filt.columns:
                 cols.append("aliases")

--- a/reporthanter/report/sections.py
+++ b/reporthanter/report/sections.py
@@ -589,8 +589,10 @@ class RawClassificationSection(_SectionBase):
 
         # Create virus-only plot
         kraken_config = self.config.get_config("filtering.kraken")
+        # The virus and domain plots force their own level/virus_only;
+        # these structural choices override the user config dict.
         virus_data, virus_unclassified = kraken_processor.filter_data(
-            kraken_data, virus_only=True, **kraken_config
+            kraken_data, **{**kraken_config, "virus_only": True}
         )
         virus_plot = kraken_plot_generator.generate_plot(
             virus_data,
@@ -600,7 +602,7 @@ class RawClassificationSection(_SectionBase):
 
         # Create domain plot
         domain_data, domain_unclassified = kraken_processor.filter_data(
-            kraken_data, level="domain", virus_only=False, **kraken_config
+            kraken_data, **{**kraken_config, "level": "domain", "virus_only": False}
         )
         domain_plot = kraken_plot_generator.generate_plot(
             domain_data,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,57 @@ from pathlib import Path
 FIXTURES = Path(__file__).parent / "fixtures"
 
 
+def _cli_args(output: Path, **overrides) -> list[str]:
+    """Build a CLI invocation against the canned fixtures.
+
+    ``overrides`` replaces individual fixture paths (e.g. ``fastp_json=...``)
+    so a test can swap one good input for a malformed one.
+    """
+    paths = {
+        "blastn_file": FIXTURES / "blastn.csv",
+        "kraken_file": FIXTURES / "kraken.tsv",
+        "kaiju_table": FIXTURES / "kaiju.tsv",
+        "fastp_json": FIXTURES / "fastp.json",
+        "flagstat_file": FIXTURES / "flagstat.txt",
+        "mosdepth_regions": FIXTURES / "mosdepth_regions.bed.gz",
+    }
+    paths.update(overrides)
+    args = [sys.executable, "-m", "reporthanter.panel_report_cli"]
+    for flag, path in paths.items():
+        args += [f"--{flag}", str(path)]
+    args += ["--output", str(output)]
+    return args
+
+
+def test_validate_only_passes_and_writes_no_report(tmp_path):
+    output = tmp_path / "report.html"
+    completed = subprocess.run(
+        _cli_args(output) + ["--validate_only"],
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    # --validate_only must not produce a report.
+    assert not output.exists()
+
+
+def test_validate_only_rejects_malformed_content(tmp_path):
+    # A present-but-corrupt fastp JSON passes the existence/size checks
+    # but must be caught by content validation.
+    bad_fastp = tmp_path / "bad_fastp.json"
+    bad_fastp.write_text("{ this is not valid json")
+    output = tmp_path / "report.html"
+
+    completed = subprocess.run(
+        _cli_args(output, fastp_json=bad_fastp) + ["--validate_only"],
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 1
+    assert not output.exists()
+    assert "could not be parsed" in (completed.stdout + completed.stderr)
+
+
 def test_cli_produces_html(tmp_path):
     output = tmp_path / "report.html"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,6 +30,37 @@ class TestDefaultConfig:
         assert plotting_config["width"] == "container"
         assert plotting_config["height"] == 400
 
+    def test_get_section_nested_dotted_path(self, default_config):
+        # Regression: get_config must resolve dotted paths into nested
+        # dicts the same way get() does, otherwise every per-processor
+        # and filtering.* section silently resolves to {} and user
+        # config overrides are ignored.
+        kraken = default_config.get_config("filtering.kraken")
+        assert kraken["cutoff"] == 0.001
+        assert kraken["max_entries"] == 10
+        assert kraken["level"] == "species"
+
+    def test_get_section_missing_returns_empty_dict(self, default_config):
+        assert default_config.get_config("filtering.does_not_exist") == {}
+        # A leaf value (not a dict) must not be returned as a section.
+        assert default_config.get_config("plotting.height") == {}
+
+    def test_config_override_reaches_section(self, tmp_path):
+        # An override of a nested threshold must be visible through
+        # get_config so processors actually receive it.
+        cfg_path = tmp_path / "override.json"
+        cfg_path.write_text(json.dumps({"filtering": {"kraken": {"cutoff": 0.5}}}))
+        config = DefaultConfig(cfg_path)
+        assert config.get_config("filtering.kraken")["cutoff"] == 0.5
+
+    def test_accepts_str_path(self, tmp_path):
+        # The documented create_report / DefaultConfig("path.json") API
+        # passes a plain string; it must not crash on `.exists()`.
+        cfg_path = tmp_path / "as_str.json"
+        cfg_path.write_text(json.dumps({"plotting": {"height": 123}}))
+        config = DefaultConfig(str(cfg_path))
+        assert config.get("plotting.height") == 123
+
     def test_get_nonexistent_key(self, default_config):
         assert default_config.get("nonexistent.key", "default") == "default"
         assert default_config.get("nonexistent.key") is None

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -7,7 +7,7 @@ import pytest
 
 from reporthanter.core.config import DefaultConfig
 from reporthanter.processors.blast_processor import BlastProcessor
-from reporthanter.report.dashboard import DashboardSection
+from reporthanter.report.dashboard import DashboardSection, _kraken_viral_percent
 
 
 @pytest.fixture
@@ -75,3 +75,45 @@ def test_dashboard_section_renders_with_fixtures(dashboard_section, dashboard_kw
 def test_dashboard_section_handles_missing_blast(dashboard_section, dashboard_kwargs):
     col = dashboard_section.generate_section(**{**dashboard_kwargs, "blastn_files": []})
     assert hasattr(col, "objects")
+
+
+# ---------------------------------------------------------------------------
+# _kraken_viral_percent — the Dashboard "Reads classified (Kraken viral)" KPI
+# must report the Viruses-domain fraction, not the total-classified fraction.
+# ``percent`` is a fraction here because KrakenProcessor.process divides by 100.
+# ---------------------------------------------------------------------------
+
+
+def _processed_kraken(rows):
+    return pd.DataFrame(
+        rows,
+        columns=["percent", "count_clades", "count", "tax_lvl", "taxonomy_id", "name", "domain"],
+    )
+
+
+def test_kraken_viral_percent_reads_viruses_domain_row():
+    df = _processed_kraken(
+        [
+            (0.03, 30, 30, "U", 0, "unclassified", "unclassified"),
+            (0.40, 400, 0, "D", 2, "Bacteria", "Bacteria"),
+            (0.12, 120, 0, "D", 10239, "Viruses", "Viruses"),
+            (0.12, 120, 50, "S", 10335, "Human alphaherpesvirus 3", "Viruses"),
+        ]
+    )
+    # Only 12% of reads are viral, even though 97% are classified to some taxon.
+    assert _kraken_viral_percent(df) == 12.0
+
+
+def test_kraken_viral_percent_viral_only_db_uses_r1_anchor():
+    df = _processed_kraken(
+        [
+            (0.97, 970, 0, "R1", 10239, "Viruses", "Viruses"),
+            (0.97, 970, 50, "S", 10335, "Human alphaherpesvirus 3", "Viruses"),
+        ]
+    )
+    assert _kraken_viral_percent(df) == 97.0
+
+
+def test_kraken_viral_percent_no_viruses_row_returns_zero():
+    df = _processed_kraken([(0.40, 400, 0, "D", 2, "Bacteria", "Bacteria")])
+    assert _kraken_viral_percent(df) == 0.0

--- a/tests/test_flagstat_processor.py
+++ b/tests/test_flagstat_processor.py
@@ -21,6 +21,22 @@ def test_parse_well_formed_flagstat():
     assert lookup["reads_unmapped"] == 550
 
 
+def test_over_100_percent_mapped_is_clamped(tmp_path):
+    # Some samtools outputs count supplementary / secondary alignments so
+    # "with itself and mate mapped" exceeds "paired in sequencing". The
+    # mapped percentage must clamp to 100 and unmapped must not go
+    # negative.
+    flagstat = tmp_path / "flagstat_over100.txt"
+    flagstat.write_text("1000 + 0 paired in sequencing\n1200 + 0 with itself and mate mapped\n")
+    proc = FlagstatProcessor()
+    df = proc.process(str(flagstat))
+
+    lookup = dict(zip(df["metric"], df["value"], strict=False))
+    assert lookup["percent_mapped"] == 100.0
+    assert lookup["reads_mapped"] == 1000
+    assert lookup["reads_unmapped"] == 0
+
+
 def test_zero_total_reads_does_not_divide_by_zero():
     proc = FlagstatProcessor()
     df = proc.process(str(FIXTURES / "flagstat_zero.txt"))


### PR DESCRIPTION
## Production-readiness: land prior work, backfill CHANGELOG, fix dashboard KPI

This branch first **captures the prior uncommitted work** sitting in the
working tree (never committed) as a `baseline:` commit, then backfills the
CHANGELOG and adds one re-audit fix.

### Commits
1. `baseline:` prior uncommitted work — shared input-validation wiring,
   `.loc` index-alignment fixes in the Kraken/Kaiju processors, the
   flagstat over-100% clamp, `DefaultConfig` dotted-path + str-path
   handling, dashboard/sections/CLI updates, and the **previously
   untracked GitHub Actions CI workflow**.
2. **docs: backfill CHANGELOG for 0.4.1-0.9.0** — the changelog stopped at
   0.7.0 while `pyproject` was 0.9.0; the missing sections (0.4.1-0.4.2,
   all 0.5.x, 0.8.0-0.8.11, 0.9.0) are reconstructed from the git tag and
   commit history so it is contiguous.
3. **fix(P1): dashboard "Reads classified (Kraken viral)" KPI** — the tile
   rendered the fraction classified to *any* taxon (overstating the viral
   signal on host/bacteria-heavy samples). New `_kraken_viral_percent`
   reads the Viruses-domain row, matching the canonical
   `kraken_virus_percent`. Adds tests.

### Verification
- `make all-checks`: ruff + mypy clean, **139 passed**, 77% coverage.

### Release tag
The `v0.9.0` tag was moved locally onto the committed tree (it previously
pointed at a commit that lacked the post-0.9.0 fixes and CHANGELOG). It is
**not pushed yet** — best pushed after this PR merges so the tag is
reachable from `main` (avoid a squash-merge dropping its target, or push
the tag at the merge commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
