### PR TITLE
Provenance surface: databases + application versions (0.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-07-01
+
+Provenance surface. Records which reference databases and application
+versions produced a report. Both public surfaces (`create_report`,
+`ReportGenerator`) are preserved; the flag and tab are optional and the
+report degrades to a "not recorded" note when no sidecar is supplied.
+
+### Added
+- New optional `--provenance_file` CLI flag (and matching
+  `create_report(provenance_file=...)` / `generate_report(...)`
+  parameter) accepting virusHanter2's `run_provenance_<batch>.json`.
+- New `Provenance` report tab (`ProvenanceSection`) listing the run
+  scalars, the reference database snapshots (build identity, not a bare
+  mtime) and the resolved tool versions. Paths are shown as
+  `folder/file` only, never absolute.
+- New `ProvenanceProcessor` (exported) that parses the sidecar into
+  run / database / software tables.
+
 ## [0.9.0] - 2026-06-04
 
 Robustness and quality hardening. Both public surfaces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ remain stable:
 --kraken_file --kaiju_table --fastp_json --flagstat_file \
 --mosdepth_regions --output \
 [--quast_report (repeatable) --genomad_summary (repeatable) \
- --virus_names --sample_name \
+ --virus_names --provenance_file --sample_name \
  --secondary_flagstat_file --secondary_host \
  --config_file --log_level --validate_only]
 ```

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ reporthanter \
 | `--virus_names` | Optional TSV from `virusHanter2`'s `bwa_align_to_kraken_hits` rule mapping chrom -> (tax_id, species, sources). When present, coverage tab labels carry the species + classifier-source suffix. |
 | `--quast_report` | Optional QUAST `report.tsv`. **Repeatable**: pass once per assembler. |
 | `--genomad_summary` | Optional geNomad `<sample>_virus_summary.tsv`. **Repeatable**: pass once per assembler. |
+| `--provenance_file` | Optional `run_provenance_<batch>.json` from `virusHanter2`. When present, a Provenance tab lists the reference database snapshots and resolved tool versions that produced the run. |
 | `--output` | Output HTML path. |
 | `--sample_name` | Optional sample identifier shown in the report header. |
 | `--secondary_flagstat_file` | Optional flagstat for a second host. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reporthanter"
-version = "0.9.0"
+version = "0.10.0"
 description = "An interactive HTML report generator for sequence classification analyses."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/reporthanter/__init__.py
+++ b/reporthanter/__init__.py
@@ -22,6 +22,7 @@ from .processors.flagstat_processor import FlagstatProcessor
 from .processors.genomad_processor import GenomadProcessor
 from .processors.kaiju_processor import KaijuPlotGenerator, KaijuProcessor
 from .processors.kraken_processor import KrakenPlotGenerator, KrakenProcessor
+from .processors.provenance_processor import ProvenanceProcessor
 from .processors.quast_processor import QuastProcessor
 
 # Main report generator
@@ -55,6 +56,7 @@ __all__ = [
     "KrakenPlotGenerator",
     "KrakenProcessor",
     "PlotGenerationError",
+    "ProvenanceProcessor",
     "QuastProcessor",
     "ReportGenerationError",
     "ReportGenerator",
@@ -81,6 +83,7 @@ def create_report(
     virus_names: str | None = None,
     genomad_summaries: list[str] | None = None,
     genomad_summary: str | None = None,
+    provenance_file: str | None = None,
     config: DefaultConfig | None = None,
 ) -> object:
     """High-level wrapper around :class:`ReportGenerator`.
@@ -139,6 +142,7 @@ def create_report(
         quast_reports=quast_paths or None,  # type: ignore[arg-type]
         virus_names=virus_names,
         genomad_summaries=genomad_paths or None,  # type: ignore[arg-type]
+        provenance_file=provenance_file,
         secondary_flagstat_file=secondary_flagstat_file,
         primary_host=primary_host,
         secondary_host=secondary_host,

--- a/reporthanter/panel_report_cli.py
+++ b/reporthanter/panel_report_cli.py
@@ -93,6 +93,17 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--provenance_file",
+        default=None,
+        help=(
+            "Optional path to the run provenance sidecar "
+            "(run_provenance_<batch>.json) written by virusHanter2. When "
+            "supplied, a Provenance tab lists the reference database "
+            "snapshots and the resolved tool versions that produced the "
+            "run. Absent -> the tab shows 'not recorded'."
+        ),
+    )
+    parser.add_argument(
         "--secondary_flagstat_file",
         default=None,
         help="Path to the secondary flagstat file (optional).",
@@ -169,6 +180,7 @@ def main() -> None:
             virus_names=args.virus_names,
             quast_reports=args.quast_report,
             genomad_summaries=args.genomad_summary,
+            provenance_file=args.provenance_file,
             secondary_flagstat_file=args.secondary_flagstat_file,
             primary_host=args.primary_host,
             secondary_host=args.secondary_host,

--- a/reporthanter/processors/provenance_processor.py
+++ b/reporthanter/processors/provenance_processor.py
@@ -1,0 +1,84 @@
+"""Provenance processor.
+
+Loads the per-run provenance sidecar that virusHanter2 writes
+(``run_provenance_<batch>.json``) into small tables the report renders:
+which reference databases (with a build identity, not a fragile mtime)
+and which resolved tool versions produced the run. The processor only
+parses -- the pipeline is the single source of truth -- and never shows
+an absolute path: the sidecar already carries short ``folder/leaf`` paths.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from ..core.config import DefaultConfig
+
+
+class ProvenanceProcessor:
+    """Parse the provenance sidecar into database / software tables."""
+
+    def __init__(self, config: dict[str, Any] | DefaultConfig | None = None) -> None:
+        self.config = config
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def load(self, path: str | Path) -> dict[str, Any]:
+        """Load the sidecar JSON, returning an empty mapping on failure.
+
+        The section degrades to a "not recorded" note rather than
+        failing the whole report when the file is absent or malformed.
+        """
+        p = Path(path)
+        if not p.is_file():
+            return {}
+        try:
+            with p.open() as fh:
+                data = json.load(fh)
+            return data if isinstance(data, dict) else {}
+        except (OSError, ValueError) as exc:
+            self.logger.warning(f"Could not read provenance sidecar {p}: {exc}")
+            return {}
+
+    def databases_frame(self, data: dict[str, Any]) -> pd.DataFrame:
+        """Return a Database / Snapshot / Date / Path table.
+
+        ``Snapshot`` is the robust build identity (e.g. ``checkv-db-v1.5``
+        or the refresh build_stats source+date); ``Path`` is the short
+        ``folder/leaf`` the sidecar recorded -- never an absolute path.
+        """
+        rows = []
+        for db in data.get("databases", []):
+            rows.append(
+                {
+                    "Database": db.get("key", ""),
+                    "Snapshot": db.get("identity", ""),
+                    "Date": db.get("date", ""),
+                    "Path": db.get("path", ""),
+                }
+            )
+        return pd.DataFrame(rows, columns=["Database", "Snapshot", "Date", "Path"])
+
+    def software_frame(self, data: dict[str, Any]) -> pd.DataFrame:
+        """Return a Tool / Version table of the resolved headline tools."""
+        headline = data.get("software_headline", {})
+        rows = [{"Tool": tool, "Version": version} for tool, version in sorted(headline.items())]
+        return pd.DataFrame(rows, columns=["Tool", "Version"])
+
+    def run_frame(self, data: dict[str, Any]) -> pd.DataFrame:
+        """Return a Field / Value table of the run-level scalars."""
+        assemblers = data.get("assemblers_used", [])
+        rows = [
+            ("Run", data.get("run_name", "")),
+            ("Generated (UTC)", data.get("generated_utc", "")),
+            ("Host removal", data.get("host_removal_tool", "")),
+            ("Assemblers", ", ".join(assemblers) if assemblers else ""),
+            ("reportHanter", data.get("reporthanter_version", "")),
+            ("Snakemake", data.get("snakemake_version", "")),
+            ("Python (driver)", data.get("python_version", "")),
+        ]
+        return pd.DataFrame([{"Field": f, "Value": v} for f, v in rows], columns=["Field", "Value"])

--- a/reporthanter/report/generator.py
+++ b/reporthanter/report/generator.py
@@ -19,6 +19,7 @@ from .sections import (
     ContigClassificationSection,
     CoverageSection,
     HostAlignmentSection,
+    ProvenanceSection,
     RawClassificationSection,
     ReadStatisticsSection,
 )
@@ -47,6 +48,7 @@ class ReportGenerator:
             "assembly": AssemblySection(self.config),
             "contig_classification": ContigClassificationSection(self.config),
             "coverage": CoverageSection(self.config),
+            "provenance": ProvenanceSection(self.config),
         }
 
     def _setup_panel(self) -> None:
@@ -91,6 +93,7 @@ class ReportGenerator:
         virus_names: str | Path | None = None,
         genomad_summaries: list[str | Path] | None = None,
         genomad_summary: str | Path | None = None,
+        provenance_file: str | Path | None = None,
     ) -> pn.Column:
         """Generate the complete report.
 
@@ -176,6 +179,14 @@ class ReportGenerator:
             virus_names=virus_names,
         )
 
+        # Provenance sits last: it is the "methods" record of which
+        # databases and tool versions produced everything above.
+        provenance_section = self._build_section(
+            "Provenance",
+            self.sections["provenance"].generate_section,
+            provenance_file=provenance_file,
+        )
+
         try:
             header = self._create_main_header(sample_name)
             main_tabs = pn.Tabs(
@@ -186,6 +197,7 @@ class ReportGenerator:
                 ("Assembly statistics", assembly_section),
                 ("Assembly classification", contig_classification_section),
                 ("Alignment coverage", coverage_section),
+                ("Provenance", provenance_section),
                 tabs_location="left",
             )
             report = pn.Column(header, pn.layout.Divider(), main_tabs)

--- a/reporthanter/report/sections.py
+++ b/reporthanter/report/sections.py
@@ -19,6 +19,7 @@ from ..processors.flagstat_processor import FlagstatProcessor
 from ..processors.genomad_processor import GenomadProcessor
 from ..processors.kaiju_processor import KaijuPlotGenerator, KaijuProcessor
 from ..processors.kraken_processor import KrakenPlotGenerator, KrakenProcessor
+from ..processors.provenance_processor import ProvenanceProcessor
 from ..processors.quast_processor import QuastProcessor
 
 
@@ -1336,3 +1337,77 @@ class CoverageSection(_SectionBase):
         )
 
         return pn.Column(header, filters, summary_block, pn.layout.Divider(), tabs)
+
+
+class ProvenanceSection(_SectionBase):
+    """Report section recording what produced the run.
+
+    Renders the machine-readable provenance sidecar virusHanter2 writes
+    (``run_provenance_<batch>.json``): the reference databases (with a
+    robust build identity rather than a fragile mtime) and the resolved
+    versions of the tools that actually ran. The section only reads the
+    sidecar -- it derives nothing -- and shows only short ``folder/leaf``
+    paths, never the operator's absolute filesystem layout. It degrades
+    to a short note when no sidecar is supplied so older callers still
+    render.
+    """
+
+    @property
+    def section_name(self) -> str:
+        return "Provenance"
+
+    def _table(self, frame: pd.DataFrame, empty_note: str) -> pn.viewable.Viewable:
+        if frame.empty:
+            return pn.pane.Markdown(empty_note, styles={"margin": "0 10px 10px 10px"})
+        return pn.widgets.Tabulator(
+            frame,
+            disabled=True,
+            show_index=False,
+            layout="fit_data_table",
+            sizing_mode="stretch_width",
+            configuration={"clipboard": True, "clipboardCopyRowRange": "active"},
+        )
+
+    def generate_section(self, **kwargs: Any) -> pn.Column:
+        provenance_file = kwargs.get("provenance_file")
+        header = self._create_header(
+            """
+            ## Provenance
+            Which reference databases and application versions produced
+            this report. Database snapshots carry a build identity (not
+            just a file date); tool versions are the conda-resolved
+            versions that actually ran. Paths are shown as folder/file
+            only.
+            """
+        )
+
+        if not provenance_file:
+            return pn.Column(
+                header,
+                pn.pane.Markdown(
+                    "Provenance was not recorded for this run.",
+                    styles={"margin": "0 10px 10px 10px"},
+                ),
+            )
+
+        processor = ProvenanceProcessor(self.config)
+        data = processor.load(provenance_file)
+        if not data:
+            return pn.Column(
+                header,
+                pn.pane.Markdown(
+                    "Provenance sidecar could not be read.",
+                    styles={"margin": "0 10px 10px 10px"},
+                ),
+            )
+
+        return pn.Column(
+            header,
+            pn.pane.Markdown("### Run", styles={"margin": "0 10px 0 10px"}),
+            self._table(processor.run_frame(data), "No run metadata recorded."),
+            pn.pane.Markdown("### Reference databases", styles={"margin": "8px 10px 0 10px"}),
+            self._table(processor.databases_frame(data), "No databases recorded."),
+            pn.pane.Markdown("### Application versions", styles={"margin": "8px 10px 0 10px"}),
+            self._table(processor.software_frame(data), "No tool versions recorded."),
+            sizing_mode="stretch_width",
+        )

--- a/tests/test_api_v3.py
+++ b/tests/test_api_v3.py
@@ -53,6 +53,7 @@ _EXPECTED_CREATE_REPORT_PARAMS = frozenset(
         "virus_names",
         "genomad_summaries",
         "genomad_summary",
+        "provenance_file",
         "config",
     }
 )

--- a/tests/test_provenance_processor.py
+++ b/tests/test_provenance_processor.py
@@ -1,0 +1,89 @@
+"""Tests for the provenance processor.
+
+The processor parses the run provenance sidecar into database / software
+tables for the report's Provenance tab, degrades gracefully when the
+sidecar is absent, and never surfaces an absolute path.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reporthanter.processors.provenance_processor import ProvenanceProcessor
+
+_SIDECAR = {
+    "run_name": "20260101_batch",
+    "generated_utc": "2026-07-01T15:00:00Z",
+    "host_removal_tool": "bwa",
+    "assemblers_used": ["MEGAHIT", "metaSPAdes"],
+    "reporthanter_version": "v0.9.0",
+    "snakemake_version": "9.23.1",
+    "python_version": "3.12.2",
+    "databases": [
+        {
+            "key": "CHECKV_DB",
+            "path": "checkv/checkv-db-v1.5",
+            "identity": "checkv-db-v1.5",
+            "date": "2024-01-10",
+        },
+        {
+            "key": "VIRUS_PARQUET",
+            "path": "virus_ref/all_viruses.parquet",
+            "identity": "refseq 2026-05-17 (14899 refs)",
+            "date": "2026-05-17",
+        },
+    ],
+    "software": [{"env": "fastp", "package": "fastp", "version": "0.24.0", "build": "b0"}],
+    "software_headline": {"fastp": "0.24.0", "kraken2": "2.1.3"},
+}
+
+
+def _write(tmp_path: Path) -> Path:
+    p = tmp_path / "run_provenance_20260101_batch.json"
+    p.write_text(json.dumps(_SIDECAR))
+    return p
+
+
+def test_load_missing_returns_empty(tmp_path):
+    proc = ProvenanceProcessor()
+    assert proc.load(tmp_path / "absent.json") == {}
+
+
+def test_databases_frame(tmp_path):
+    proc = ProvenanceProcessor()
+    data = proc.load(_write(tmp_path))
+    df = proc.databases_frame(data)
+    assert list(df.columns) == ["Database", "Snapshot", "Date", "Path"]
+    checkv = df[df["Database"] == "CHECKV_DB"].iloc[0]
+    assert checkv["Snapshot"] == "checkv-db-v1.5"
+    # Short path only; no absolute path leaks.
+    assert checkv["Path"] == "checkv/checkv-db-v1.5"
+    assert not df["Path"].str.startswith("/").any()
+
+
+def test_software_frame_is_headline_sorted(tmp_path):
+    proc = ProvenanceProcessor()
+    data = proc.load(_write(tmp_path))
+    df = proc.software_frame(data)
+    assert list(df.columns) == ["Tool", "Version"]
+    assert df.iloc[0]["Tool"] == "fastp"
+    assert df.iloc[0]["Version"] == "0.24.0"
+    assert set(df["Tool"]) == {"fastp", "kraken2"}
+
+
+def test_run_frame_carries_scalars(tmp_path):
+    proc = ProvenanceProcessor()
+    data = proc.load(_write(tmp_path))
+    df = proc.run_frame(data)
+    lookup = dict(zip(df["Field"], df["Value"], strict=True))
+    assert lookup["Host removal"] == "bwa"
+    assert lookup["Assemblers"] == "MEGAHIT, metaSPAdes"
+    assert lookup["reportHanter"] == "v0.9.0"
+
+
+def test_frames_empty_on_missing_sidecar():
+    proc = ProvenanceProcessor()
+    data: dict = {}
+    assert proc.databases_frame(data).empty
+    assert proc.software_frame(data).empty

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -56,11 +56,64 @@ def test_generate_report_has_header_and_tabs(full_report):
     assert len(full_report.objects) >= 3
 
 
-def test_generate_report_tabs_have_seven_sections(full_report):
+def test_generate_report_tabs_have_eight_sections(full_report):
     import panel as pn
 
     tabs = next(o for o in full_report.objects if isinstance(o, pn.Tabs))
-    assert len(tabs) == 7
+    # Dashboard, Read statistics, Host alignment, Classification of reads,
+    # Assembly statistics, Assembly classification, Alignment coverage,
+    # Provenance.
+    assert len(tabs) == 8
+    assert list(tabs._names) == [
+        "Dashboard",
+        "Read statistics",
+        "Host alignment",
+        "Classification of reads",
+        "Assembly statistics",
+        "Assembly classification",
+        "Alignment coverage",
+        "Provenance",
+    ]
+
+
+def test_provenance_tab_renders_from_sidecar(generator, tmp_path):
+    import json
+
+    import panel as pn
+
+    sidecar = tmp_path / "run_provenance_batch.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "run_name": "batch",
+                "databases": [
+                    {
+                        "key": "CHECKV_DB",
+                        "path": "checkv/checkv-db-v1.5",
+                        "identity": "checkv-db-v1.5",
+                        "date": "2024-01-10",
+                    }
+                ],
+                "software_headline": {"fastp": "0.24.0"},
+            }
+        )
+    )
+    report = generator.generate_report(
+        blastn_files=[str(FIXTURES / "blastn.csv")],
+        kraken_file=str(FIXTURES / "kraken.tsv"),
+        kaiju_table=str(FIXTURES / "kaiju.tsv"),
+        fastp_json=str(FIXTURES / "fastp.json"),
+        flagstat_file=str(FIXTURES / "flagstat.txt"),
+        mosdepth_regions=str(FIXTURES / "mosdepth_regions.bed.gz"),
+        provenance_file=str(sidecar),
+        sample_name="pytest_sample",
+    )
+    tabs = next(o for o in report.objects if isinstance(o, pn.Tabs))
+    prov_tab = tabs[list(tabs._names).index("Provenance")]
+    # With a sidecar the section renders header + three labelled tables
+    # (run / databases / software), not the single "not recorded" note.
+    assert isinstance(prov_tab, pn.Column)
+    assert len(prov_tab.objects) >= 4
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Records which reference databases and application versions produced a report.

- New optional `--provenance_file` CLI flag (and matching `create_report(provenance_file=...)` / `generate_report(...)` parameter) accepting virusHanter2's `run_provenance_<batch>.json`.
- New **Provenance** report tab (`ProvenanceSection` + exported `ProvenanceProcessor`): run scalars, reference database snapshots (build identity, not a bare mtime), and resolved tool versions. Paths are shown as `folder/file` only, never absolute.
- Degrades to a "not recorded" note when no sidecar is supplied. Both public surfaces (`create_report`, `ReportGenerator`) preserved.
- Bumps version `0.9.0` -> `0.10.0`.

## Verification

`make all-checks` green (145 tests, ruff + mypy clean). New `test_provenance_processor.py` plus generator render test with a sidecar.

## Release note

Tag **`v0.10.0`** must be published after merge: virusHanter2 pins `reporthanter.git@v0.10.0`, so its build/CI cannot resolve the flag until this tag exists on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)