### PR TITLE
Tolerate empty Kraken/Kaiju for zero-read samples (0.10.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-07-02
+
+Robustness for samples with zero reads reaching classification (an
+all-host sample, or fastp dropping every read). Backward compatible.
+
+### Changed
+- The Kraken and Kaiju inputs may now be **empty**: `KrakenProcessor` and
+  `KaijuProcessor` tolerate a 0-byte file and return an empty frame
+  carrying the expected columns, and `core.validation` moves Kraken/Kaiju
+  from required-non-empty to exist-but-may-be-empty (FastP, Flagstat and
+  Mosdepth stay required non-empty). The report then renders with empty
+  Classification charts instead of failing. Trade-off: a genuinely
+  truncated Kraken/Kaiju file now renders an empty report rather than
+  being rejected at validation.
+
 ## [0.10.0] - 2026-07-01
 
 Provenance surface. Records which reference databases and application

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reporthanter"
-version = "0.10.0"
+version = "0.10.1"
 description = "An interactive HTML report generator for sequence classification analyses."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/reporthanter/core/validation.py
+++ b/reporthanter/core/validation.py
@@ -57,16 +57,18 @@ def validate_report_inputs(
     file raises :exc:`~reporthanter.core.exceptions.ConfigurationError`
     with a clear message naming the offending path:
 
-    * Kraken TSV (required, non-empty)
-    * Kaiju TSV (required, non-empty)
     * FastP JSON (required, non-empty)
     * Flagstat file (required, non-empty)
     * Mosdepth regions BED/BED.GZ (required, non-empty)
 
-    BLAST CSVs are the one exception: an empty CSV simply indicates that
-    the upstream assembler produced no contigs for this sample.  The
-    report still renders with an empty contig table.  At least one BLAST
-    path must be supplied, but the file itself may be zero bytes.
+    The Kraken TSV, Kaiju TSV and BLAST CSVs must exist but may be
+    empty. A sample with zero reads reaching classification can leave a
+    0-byte Kraken/Kaiju report, and an empty BLAST CSV simply means the
+    assembler produced no contigs; in all three cases the report still
+    renders (with empty Classification / contig charts) rather than
+    failing. At least one BLAST path must be supplied. Trade-off: a
+    genuinely truncated Kraken/Kaiju file now renders an empty report
+    instead of being rejected here.
 
     Optional inputs (secondary flagstat, virus names TSV, QUAST reports,
     geNomad summaries) are checked for existence and non-empty size only
@@ -81,13 +83,16 @@ def validate_report_inputs(
 
     # Required singleton inputs (non-empty).
     for name, path in (
-        ("Kraken file", kraken_file),
-        ("Kaiju table", kaiju_table),
         ("FastP JSON", fastp_json),
         ("Flagstat file", flagstat_file),
         ("Mosdepth regions file", mosdepth_regions),
     ):
         errors.extend(_check_file(name, path))
+
+    # Kraken / Kaiju: must exist, but may be empty (zero reads reaching
+    # classification). The processors render empty Classification charts.
+    for name, path in (("Kraken file", kraken_file), ("Kaiju table", kaiju_table)):
+        errors.extend(_check_file(name, path, require_nonempty=False))
 
     # BLAST CSVs: at least one required; empty files are tolerated.
     blast_paths = list(blastn_files or [])

--- a/reporthanter/processors/kaiju_processor.py
+++ b/reporthanter/processors/kaiju_processor.py
@@ -17,9 +17,28 @@ from ..core.palettes import TAXONOMY_COLORS
 class KaijuProcessor(BaseDataProcessor):
     """Processes Kaiju TSV files into standardized DataFrames."""
 
+    # Columns of an empty Kaiju frame, so the filter's `taxon_name` /
+    # `percent` access does not KeyError when a sample had zero reads
+    # reaching classification.
+    _EMPTY_COLUMNS = ["percent", "reads", "taxon_id", "taxon_name"]
+
     def validate_input(self, file_path: str | Path) -> bool:
-        """Validate Kaiju file format."""
-        super().validate_input(file_path)
+        """Validate Kaiju file format.
+
+        An empty file is tolerated: a sample with zero reads reaching
+        classification can leave a 0-byte Kaiju table, in which case the
+        report renders with empty Classification charts rather than
+        failing. Existence and regular-file checks still apply.
+        """
+        from ..core.exceptions import FileValidationError
+
+        fp = Path(file_path)
+        if not fp.exists():
+            raise FileValidationError(f"File does not exist: {file_path}")
+        if not fp.is_file():
+            raise FileValidationError(f"Path is not a file: {file_path}")
+        if fp.stat().st_size == 0:
+            return True
 
         # Check if it looks like a Kaiju file
         try:
@@ -28,6 +47,8 @@ class KaijuProcessor(BaseDataProcessor):
             if not required_columns.issubset(test_df.columns):
                 missing = required_columns - set(test_df.columns)
                 raise DataProcessingError(f"Missing required columns in Kaiju file: {missing}")
+        except DataProcessingError:
+            raise
         except Exception as e:
             raise DataProcessingError(f"Invalid Kaiju file format: {e}") from e
 
@@ -40,6 +61,9 @@ class KaijuProcessor(BaseDataProcessor):
         alongside the canonicalised ``taxon_name`` so they cannot
         leak through the Vega data embed into the rendered HTML.
         """
+        if Path(file_path).stat().st_size == 0:
+            return pd.DataFrame(columns=self._EMPTY_COLUMNS)
+
         df = pd.read_csv(file_path, sep="\t")
         drop = [c for c in df.columns if c.endswith("_raw")]
         if drop:

--- a/reporthanter/processors/kaiju_processor.py
+++ b/reporthanter/processors/kaiju_processor.py
@@ -17,10 +17,21 @@ from ..core.palettes import TAXONOMY_COLORS
 class KaijuProcessor(BaseDataProcessor):
     """Processes Kaiju TSV files into standardized DataFrames."""
 
-    # Columns of an empty Kaiju frame, so the filter's `taxon_name` /
-    # `percent` access does not KeyError when a sample had zero reads
-    # reaching classification.
-    _EMPTY_COLUMNS = ["percent", "reads", "taxon_id", "taxon_name"]
+    @staticmethod
+    def _empty_frame() -> pd.DataFrame:
+        """An empty Kaiju frame with the expected columns and numeric
+        columns typed as numeric. Leaving ``percent`` as object dtype
+        would make the Dashboard's ``(percent * 100).round(2)`` raise on
+        pandas 2.x for a sample with zero reads reaching classification.
+        """
+        return pd.DataFrame(
+            {
+                "percent": pd.Series(dtype="float64"),
+                "reads": pd.Series(dtype="int64"),
+                "taxon_id": pd.Series(dtype="float64"),
+                "taxon_name": pd.Series(dtype="object"),
+            }
+        )
 
     def validate_input(self, file_path: str | Path) -> bool:
         """Validate Kaiju file format.
@@ -62,7 +73,7 @@ class KaijuProcessor(BaseDataProcessor):
         leak through the Vega data embed into the rendered HTML.
         """
         if Path(file_path).stat().st_size == 0:
-            return pd.DataFrame(columns=self._EMPTY_COLUMNS)
+            return self._empty_frame()
 
         df = pd.read_csv(file_path, sep="\t")
         drop = [c for c in df.columns if c.endswith("_raw")]

--- a/reporthanter/processors/kraken_processor.py
+++ b/reporthanter/processors/kraken_processor.py
@@ -27,9 +27,36 @@ class KrakenProcessor(BaseDataProcessor):
         "species": "S",
     }
 
+    # Columns of an empty Kraken frame (raw six plus the derived domain),
+    # so downstream filters that reference `domain` / `tax_lvl` do not
+    # KeyError when a sample had zero reads reaching classification.
+    _EMPTY_COLUMNS = [
+        "percent",
+        "count_clades",
+        "count",
+        "tax_lvl",
+        "taxonomy_id",
+        "name",
+        "domain",
+    ]
+
     def validate_input(self, file_path: str | Path) -> bool:
-        """Validate Kraken file format."""
-        super().validate_input(file_path)
+        """Validate Kraken file format.
+
+        An empty file is tolerated: a sample with zero reads reaching
+        classification can leave a 0-byte Kraken report, in which case
+        the report renders with empty Classification charts rather than
+        failing. Existence and regular-file checks still apply.
+        """
+        from ..core.exceptions import FileValidationError
+
+        fp = Path(file_path)
+        if not fp.exists():
+            raise FileValidationError(f"File does not exist: {file_path}")
+        if not fp.is_file():
+            raise FileValidationError(f"Path is not a file: {file_path}")
+        if fp.stat().st_size == 0:
+            return True
 
         # Check if it looks like a Kraken file
         try:
@@ -38,6 +65,8 @@ class KrakenProcessor(BaseDataProcessor):
                 raise DataProcessingError(
                     f"Expected 6 columns in Kraken file, got {test_df.shape[1]}"
                 )
+        except DataProcessingError:
+            raise
         except Exception as e:
             raise DataProcessingError(f"Invalid Kraken file format: {e}") from e
 
@@ -54,6 +83,9 @@ class KrakenProcessor(BaseDataProcessor):
         is unaffected because its only R1 row ("cellular organisms")
         is immediately overridden by the next D row (Bacteria).
         """
+        if Path(file_path).stat().st_size == 0:
+            return pd.DataFrame(columns=self._EMPTY_COLUMNS)
+
         df = pd.read_csv(
             file_path,
             sep="\t",

--- a/reporthanter/processors/kraken_processor.py
+++ b/reporthanter/processors/kraken_processor.py
@@ -27,18 +27,25 @@ class KrakenProcessor(BaseDataProcessor):
         "species": "S",
     }
 
-    # Columns of an empty Kraken frame (raw six plus the derived domain),
-    # so downstream filters that reference `domain` / `tax_lvl` do not
-    # KeyError when a sample had zero reads reaching classification.
-    _EMPTY_COLUMNS = [
-        "percent",
-        "count_clades",
-        "count",
-        "tax_lvl",
-        "taxonomy_id",
-        "name",
-        "domain",
-    ]
+    @staticmethod
+    def _empty_frame() -> pd.DataFrame:
+        """An empty Kraken frame with the raw six columns plus the derived
+        ``domain``, and -- crucially -- the numeric columns typed as
+        numeric. A sample with zero reads reaching classification yields
+        this; leaving ``percent`` as object dtype would make the
+        Dashboard's ``(percent * 100).round(2)`` raise on pandas 2.x.
+        """
+        return pd.DataFrame(
+            {
+                "percent": pd.Series(dtype="float64"),
+                "count_clades": pd.Series(dtype="int64"),
+                "count": pd.Series(dtype="int64"),
+                "tax_lvl": pd.Series(dtype="object"),
+                "taxonomy_id": pd.Series(dtype="int64"),
+                "name": pd.Series(dtype="object"),
+                "domain": pd.Series(dtype="object"),
+            }
+        )
 
     def validate_input(self, file_path: str | Path) -> bool:
         """Validate Kraken file format.
@@ -84,7 +91,7 @@ class KrakenProcessor(BaseDataProcessor):
         is immediately overridden by the next D row (Bacteria).
         """
         if Path(file_path).stat().st_size == 0:
-            return pd.DataFrame(columns=self._EMPTY_COLUMNS)
+            return self._empty_frame()
 
         df = pd.read_csv(
             file_path,

--- a/tests/test_kaiju_processor.py
+++ b/tests/test_kaiju_processor.py
@@ -23,6 +23,9 @@ def test_empty_kaiju_file_is_tolerated(tmp_path):
     df = proc.process(str(empty))
     assert df.empty
     assert {"percent", "taxon_name"}.issubset(df.columns)
+    # `percent` must be numeric even when empty: the Dashboard does
+    # (percent * 100).round(2), which raises on an object dtype (pandas 2.x).
+    assert df["percent"].dtype.kind == "f"
 
     filtered, unclassified_pct = proc.filter_data(df, cutoff=0.01, max_entries=10)
     assert filtered.empty

--- a/tests/test_kaiju_processor.py
+++ b/tests/test_kaiju_processor.py
@@ -11,6 +11,24 @@ from reporthanter.processors.kaiju_processor import KaijuProcessor
 FIXTURES = Path(__file__).parent / "fixtures"
 
 
+def test_empty_kaiju_file_is_tolerated(tmp_path):
+    # A sample with zero reads reaching Kaiju can leave a 0-byte table;
+    # validate + process must not raise, and filter_data must return an
+    # empty frame + 0.0 so the Classification tab renders a placeholder.
+    empty = tmp_path / "empty.kaiju.tsv"
+    empty.touch()
+    proc = KaijuProcessor()
+
+    assert proc.validate_input(empty) is True
+    df = proc.process(str(empty))
+    assert df.empty
+    assert {"percent", "taxon_name"}.issubset(df.columns)
+
+    filtered, unclassified_pct = proc.filter_data(df, cutoff=0.01, max_entries=10)
+    assert filtered.empty
+    assert unclassified_pct == 0.0
+
+
 def test_process_normalizes_percent_to_fraction():
     proc = KaijuProcessor()
     df = proc.process(str(FIXTURES / "kaiju.tsv"))

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -35,6 +35,9 @@ class TestKrakenProcessor:
         df = kraken_processor.process(empty_file)
         assert df.empty
         assert {"domain", "tax_lvl", "name", "percent"}.issubset(df.columns)
+        # `percent` must be numeric even when empty: the Dashboard does
+        # (percent * 100).round(2), which raises on object dtype (pandas 2.x).
+        assert df["percent"].dtype.kind == "f"
 
         filtered, unclassified_pct = kraken_processor.filter_data(df, level="species")
         assert filtered.empty

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -24,11 +24,21 @@ class TestKrakenProcessor:
         with pytest.raises(FileValidationError, match="File does not exist"):
             kraken_processor.validate_input("/nonexistent/file.tsv")
 
-    def test_validate_input_empty_file(self, kraken_processor, tmp_path):
+    def test_validate_input_empty_file_is_tolerated(self, kraken_processor, tmp_path):
+        # A 0-byte Kraken report (zero reads reaching classification) is
+        # allowed; process returns an empty frame carrying the schema so
+        # the Classification tab renders a placeholder.
         empty_file = tmp_path / "empty.tsv"
         empty_file.touch()
-        with pytest.raises(FileValidationError, match="File is empty"):
-            kraken_processor.validate_input(empty_file)
+        assert kraken_processor.validate_input(empty_file) is True
+
+        df = kraken_processor.process(empty_file)
+        assert df.empty
+        assert {"domain", "tax_lvl", "name", "percent"}.issubset(df.columns)
+
+        filtered, unclassified_pct = kraken_processor.filter_data(df, level="species")
+        assert filtered.empty
+        assert unclassified_pct == 0.0
 
     def test_validate_input_valid_kraken_file(self, kraken_processor, tmp_path):
         kraken_file = tmp_path / "ok.tsv"

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -76,6 +76,33 @@ def test_generate_report_tabs_have_eight_sections(full_report):
     ]
 
 
+def test_report_renders_with_empty_kraken_kaiju_blast(generator, tmp_path):
+    # A sample with zero reads reaching classification: 0-byte Kraken and
+    # Kaiju reports and an empty BLAST CSV. The whole report must still
+    # render (placeholders), not crash -- the "finish with an empty
+    # report" contract.
+    empty_kraken = tmp_path / "empty_kraken.tsv"
+    empty_kraken.touch()
+    empty_kaiju = tmp_path / "empty_kaiju.tsv"
+    empty_kaiju.touch()
+    empty_blast = tmp_path / "empty_blast.csv"
+    empty_blast.touch()
+
+    report = generator.generate_report(
+        blastn_files=[str(empty_blast)],
+        kraken_file=str(empty_kraken),
+        kaiju_table=str(empty_kaiju),
+        fastp_json=str(FIXTURES / "fastp.json"),
+        flagstat_file=str(FIXTURES / "flagstat.txt"),
+        mosdepth_regions=str(FIXTURES / "mosdepth_regions.bed.gz"),
+        sample_name="all_host_sample",
+    )
+    output = tmp_path / "empty_report.html"
+    generator.save_report(report, output, title="empty")
+    assert output.exists()
+    assert output.stat().st_size > 10_000
+
+
 def test_provenance_tab_renders_from_sidecar(generator, tmp_path):
     import json
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -88,13 +88,46 @@ def test_no_blast_files_raises():
 
 
 def test_empty_required_file_raises(tmp_path):
-    """A zero-byte required file is rejected."""
-    empty_kraken = tmp_path / "empty_kraken.tsv"
-    empty_kraken.touch()
+    """A zero-byte still-required file (FastP) is rejected."""
+    empty_fastp = tmp_path / "empty_fastp.json"
+    empty_fastp.touch()
 
     with pytest.raises(ConfigurationError):
         validate_report_inputs(
-            kraken_file=str(empty_kraken),
+            kraken_file=str(FIXTURES / "kraken.tsv"),
+            kaiju_table=str(FIXTURES / "kaiju.tsv"),
+            fastp_json=str(empty_fastp),
+            flagstat_file=str(FIXTURES / "flagstat.txt"),
+            mosdepth_regions=str(FIXTURES / "mosdepth_regions.bed.gz"),
+            blastn_files=[str(FIXTURES / "blastn.csv")],
+        )
+
+
+def test_empty_kraken_and_kaiju_are_tolerated(tmp_path):
+    """Zero-byte Kraken/Kaiju reports pass validation (zero reads reaching
+    classification): the report renders with empty Classification charts."""
+    empty_kraken = tmp_path / "empty_kraken.tsv"
+    empty_kraken.touch()
+    empty_kaiju = tmp_path / "empty_kaiju.tsv"
+    empty_kaiju.touch()
+
+    # Must not raise.
+    validate_report_inputs(
+        kraken_file=str(empty_kraken),
+        kaiju_table=str(empty_kaiju),
+        fastp_json=str(FIXTURES / "fastp.json"),
+        flagstat_file=str(FIXTURES / "flagstat.txt"),
+        mosdepth_regions=str(FIXTURES / "mosdepth_regions.bed.gz"),
+        blastn_files=[str(FIXTURES / "blastn.csv")],
+    )
+
+
+def test_missing_kraken_still_raises(tmp_path):
+    """Tolerating *empty* does not tolerate *missing*: a non-existent
+    Kraken file is still a validation error."""
+    with pytest.raises(ConfigurationError):
+        validate_report_inputs(
+            kraken_file=str(tmp_path / "absent_kraken.tsv"),
             kaiju_table=str(FIXTURES / "kaiju.tsv"),
             fastp_json=str(FIXTURES / "fastp.json"),
             flagstat_file=str(FIXTURES / "flagstat.txt"),


### PR DESCRIPTION
## Summary

A sample with zero reads reaching classification (all-host, or fastp drops every read) can leave a 0-byte Kraken/Kaiju report. This makes the report finish with empty Classification charts instead of failing.

- `KrakenProcessor` / `KaijuProcessor`: allow a 0-byte file (mirroring `BlastProcessor`); `_process_file` returns an empty frame carrying the expected columns so `filter_data` and the sections render placeholders.
- `core/validation.py`: Kraken/Kaiju move from required-non-empty to exist-but-may-be-empty. FastP/Flagstat/Mosdepth stay required non-empty. Trade-off documented: a genuinely truncated Kraken/Kaiju file now renders an empty report rather than being rejected.
- Bumps `0.10.0` -> `0.10.1`.

## Verification

`make all-checks` green (149 tests, ruff + mypy clean). New tests: processor empty-tolerance, validation allows empty Kraken/Kaiju (but still rejects *missing*), and a full report render from 0-byte Kraken+Kaiju+BLAST (>10 KB HTML).

## Release note

Tag **`v0.10.1`** must be published after merge: virusHanter2 bumps its pin to `reporthanter.git@v0.10.1` so the pipeline's `generate_report` inherits this tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)