### PR TITLE
Require pandas >= 3 (0.10.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] - 2026-07-02
+
+### Changed
+- Require **pandas >= 3** (was `>=2.0,<3`). This removes the 2.x/3.x
+  split where CI resolved pandas 2.x while development used 3.x, which
+  masked a dtype-reduction difference (an object-dtype empty column that
+  `.round()` tolerates on 3.x but rejects on 2.x). One pandas major
+  across development, CI and production.
+
 ## [0.10.1] - 2026-07-02
 
 Robustness for samples with zero reads reaching classification (an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reporthanter"
-version = "0.10.1"
+version = "0.10.2"
 description = "An interactive HTML report generator for sequence classification analyses."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "pandas>=2.0,<3",
+    "pandas>=3",
     "numpy>=1.24",
     "altair>=6.0,<7",
     "panel>=1.3,<2",


### PR DESCRIPTION
## Summary

Drop the `pandas>=2.0,<3` cap in favour of **`pandas>=3`**. CI resolved pandas 2.x while development ran 3.x; that split masked a dtype-reduction difference (an object-dtype empty column that `.round()` tolerates on 3.x but rejects on 2.x — the Dashboard bug caught in #8). One pandas major across development, CI and production.

Bumps `0.10.1` -> `0.10.2`.

## Verification

`make all-checks` green on pandas 3.0.3 (149 tests, ruff + mypy clean). CI now also runs pandas 3.x, matching development.

## Release note

Tag **`v0.10.2`** after merge: virusHanter2 bumps its pin to `@v0.10.2` and its conda envs to `pandas>=3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)