### PR TITLE
Dependency audit: numpy 2 floor (0.10.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.3] - 2026-07-02
+
+### Changed
+- Move the numpy floor to the numpy 2 generation (`numpy>=2`, was
+  `>=1.24`), matching the `pandas>=3` requirement. The altair / panel /
+  pyfastx ranges already float to the current latest (their major caps
+  do not block it), so they are unchanged. reportHanter is pip-installed,
+  so its dependencies resolve to the latest release from the index at
+  install time.
+
 ## [0.10.2] - 2026-07-02
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reporthanter"
-version = "0.10.2"
+version = "0.10.3"
 description = "An interactive HTML report generator for sequence classification analyses."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "pandas>=3",
-    "numpy>=1.24",
+    "numpy>=2",
     "altair>=6.0,<7",
     "panel>=1.3,<2",
     "pyfastx>=2.0,<3",


### PR DESCRIPTION
## Summary

Dependency audit. reportHanter is pip-installed, so its deps already resolve to the latest release satisfying their ranges; the only stale floor was numpy. Set **`numpy>=2`** (was `>=1.24`) to match `pandas>=3` (pandas 3 requires numpy 2.x). altair / panel / pyfastx ranges already float to the current latest (`6.2.2`, `1.9.3`, `2.3.1`), so they are unchanged.

Bumps `0.10.2` -> `0.10.3`.

## Verification

`make all-checks` green (149 tests, ruff + mypy clean).

## Release note

Tag **`v0.10.3`** after merge: virusHanter2 bumps its pin to `@v0.10.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)